### PR TITLE
Support get_port_or_cage_type

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -7,7 +7,7 @@
 
 import sys
 from . import device_base
-
+from . import sfp_base
 
 class ChassisBase(device_base.DeviceBase):
     """
@@ -498,6 +498,27 @@ class ChassisBase(device_base.DeviceBase):
 
         return sfp
 
+
+    def get_port_or_cage_type(self, index):
+        """
+        Retrieves sfp port or cage type corresponding to physical port <index>
+
+        Args:
+            index: An integer (>=0), the index of the sfp to retrieve.
+                   The index should correspond to the physical port in a chassis.
+                   For example:-
+                   1 for Ethernet0, 2 for Ethernet4 and so on for one platform.
+                   0 for Ethernet0, 1 for Ethernet4 and so on for another platform.
+
+        Returns:
+            The masks of all types of port or cage that can be supported on the port
+            Types are defined in sfp_base.py
+            Eg.
+                Both SFP and SFP+ are supported on the port, the return value should be 0x0a
+                which is 0x02 | 0x08
+        """
+        raise NotImplementedError
+
     ##############################################
     # System LED methods
     ##############################################
@@ -582,4 +603,3 @@ class ChassisBase(device_base.DeviceBase):
                       status='6' Bad cable.
         """
         raise NotImplementedError
-

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -52,6 +52,21 @@ class SfpBase(device_base.DeviceBase):
         SFP_ERROR_BIT_BAD_CABLE:               SFP_ERROR_DESCRIPTION_BAD_CABLE
     }
 
+    SFP_PORT_TYPE_BIT_RJ45                = 0x00000001
+    SFP_PORT_TYPE_BIT_SFP                 = 0x00000002
+    SFP_PORT_TYPE_BIT_XFP                 = 0x00000004
+    SFP_PORT_TYPE_BIT_SFP_PLUS            = 0x00000008
+    SFP_PORT_TYPE_BIT_QSFP                = 0x00000010
+    SFP_PORT_TYPE_BIT_CFP                 = 0x00000020
+    SFP_PORT_TYPE_BIT_QSFP_PLUS           = 0x00000040
+    SFP_PORT_TYPE_BIT_QSFP28              = 0x00000080
+    SFP_PORT_TYPE_BIT_SFP28               = 0x00000100
+    SFP_PORT_TYPE_BIT_CFP2                = 0x00000200
+    SFP_PORT_TYPE_BIT_QSFP56              = 0x00000400
+    SFP_PORT_TYPE_BIT_QSFPDD              = 0x00000800
+    SFP_PORT_TYPE_BIT_OSFP                = 0x00001000
+    SFP_PORT_TYPE_BIT_SFP_DD              = 0x00002000
+
     def __init__(self):
         # List of ThermalBase-derived objects representing all thermals
         # available on the SFP


### PR DESCRIPTION
The API returns the masks of all types of port or cage that can be supported on the port
All the types are defined in sfp_base.SfpBase

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

