### PR TITLE
Fix memory map parsing issue

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8636.py
@@ -60,6 +60,7 @@ class Sff8636Codes(Sff8024):
         32: "10GBASE-LR",
         64: "10GBASE-LRM",
         128: "Extended",
+        136: "40GBASE-CR4,Extended"
     }
 
     SONET_COMPLIANCE = {

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
@@ -50,9 +50,7 @@ class Sff8636MemMap(XcvrMemMap):
             ),
             CodeRegField(consts.CONNECTOR_FIELD, self.get_addr(0, 130), self.codes.CONNECTORS),
             RegGroupField(consts.SPEC_COMPLIANCE_FIELD, 
-                CodeRegField(consts.ETHERNET_10_40G_COMPLIANCE_FIELD, self.get_addr(0, 131), self.codes.ETHERNET_10_40G_COMPLIANCE,
-                    *(RegBitField("%s_%d" % (consts.ETHERNET_10_40G_COMPLIANCE_FIELD, bit), bit) for bit in range(0, 7))
-                ),
+                CodeRegField(consts.ETHERNET_10_40G_COMPLIANCE_FIELD, self.get_addr(0, 131), self.codes.ETHERNET_10_40G_COMPLIANCE),
                 CodeRegField(consts.SONET_COMPLIANCE_FIELD, self.get_addr(0, 132), self.codes.SONET_COMPLIANCE),
                 CodeRegField(consts.SAS_SATA_COMPLIANCE_FIELD, self.get_addr(0, 133), self.codes.SAS_SATA_COMPLIANCE),
                 CodeRegField(consts.GIGABIT_ETHERNET_COMPLIANCE_FIELD, self.get_addr(0, 134), self.codes.GIGABIT_ETHERNET_COMPLIANCE),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Fix memory map parsing issue for SFF8636: `extended` can not be parsed from `10/40G Ethernet Compliance Code` due to being masked.
The field `10/40G Ethernet Compliance Code` is a bit field but is parsed as an enumeration with the assumption that only 1 bit can be set, which fails to parse a value in case more than 1 bit is set. However, the bit `extended` can co-exist with bit `40GBASE-CR4`, which means the parsing logic can fail in such cases.
In PR 412 the `extended` bit was masked out but it failed to parse `extended` bit as a result.
In this PR, the combination `extended` + `40GBASE-CR4` is handled by adding the value to the enumeration.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

